### PR TITLE
BUGFIX: Klaro not able to unblock / application/json+ld should not be blocked

### DIFF
--- a/Classes/TagHelper.php
+++ b/Classes/TagHelper.php
@@ -18,8 +18,12 @@ class TagHelper
     const DATA_NEVER_BLOCK = "data-never-block";
 
     // Type Constants
-    const TEXT_PLAIN = "text/plain";
-    const TEXT_JAVASCRIPT = "text/javascript";
+    const TYPE_TEXT_PLAIN = "text/plain";
+    const TYPE_APPLICATION_JSON_LD = "application/ld+json";
+
+    // TODO: switch to "text/javascript" at some point
+    // update tests
+    const TYPE_JAVASCRIPT = "text/javascript";
 
     /**
      * @param string $tag
@@ -66,6 +70,19 @@ class TagHelper
             },
             $tag
         );
+    }
+
+    /**
+     * @param string $tag
+     * @param string $name
+     * @return string
+     */
+    static function tagGetAttributeValue(
+        string $tag,
+        string $name
+    ): ?string {
+        preg_match(self::buildMatchAttributeNameWithAnyValueReqex($name), $tag, $matches);
+        return isset($matches['value']) ? $matches['value'] : null;
     }
 
     /**

--- a/Tests/Unit/Eel/Helper/CookiePunchTest.php
+++ b/Tests/Unit/Eel/Helper/CookiePunchTest.php
@@ -6,7 +6,7 @@ use Neos\Utility\ObjectAccess;
 use Sandstorm\CookiePunch\Eel\Helper\CookiePunch;
 
 /**
- * Testcase for the ConvertNodeUris Fusion implementation
+ * Testcase
  */
 class CookiePunchTest extends UnitTestCase
 {
@@ -48,10 +48,11 @@ class CookiePunchTest extends UnitTestCase
         self::assertEquals($expected, $actual);
 
         // ### <script> with src attribute ###
-
+        // IMPORTANT: we need to add data-type="text/javascript" here to prevent Klaro from
+        // not correctly recovering the correct value.
         $markup = '<script src="myscripts.js"></script>';
         $expected =
-            '<script data-src="myscripts.js" data-name="default"></script>';
+            '<script data-src="myscripts.js" data-type="text/javascript" data-name="default"></script>';
         $actual = $blockExternalContentHelper->blockScripts($markup);
         self::assertEquals($expected, $actual);
 
@@ -67,6 +68,14 @@ class CookiePunchTest extends UnitTestCase
         $markup = '<script src="myscripts.js" type="text/javascript"/>';
         $expected =
             '<script data-src="myscripts.js" data-type="text/javascript" type="text/plain" data-name="default"/>';
+        $actual = $blockExternalContentHelper->blockScripts($markup);
+        self::assertEquals($expected, $actual);
+
+        // ### <script> with "application/javascript" or other types will be blocked ###
+        $markup =
+            '<script src="myscripts.js" defer type="application/javascript"></script>';
+        $expected =
+            '<script data-src="myscripts.js" defer data-type="application/javascript" type="text/plain" data-name="default"></script>';
         $actual = $blockExternalContentHelper->blockScripts($markup);
         self::assertEquals($expected, $actual);
     }
@@ -86,7 +95,7 @@ class CookiePunchTest extends UnitTestCase
 
         $markup = '<script src="myscripts.js" data-name="default"></script>';
         $expected =
-            '<script data-src="myscripts.js" data-name="default"></script>';
+            '<script data-src="myscripts.js" data-name="default" data-type="text/javascript"></script>';
         $actual = $blockExternalContentHelper->blockScripts($markup);
         self::assertEquals($expected, $actual);
 
@@ -112,7 +121,7 @@ class CookiePunchTest extends UnitTestCase
         );
 
         $markup = '<script src="myscripts.js"></script>';
-        $expected = '<script data-src="myscripts.js" data-name="foo"></script>';
+        $expected = '<script data-src="myscripts.js" data-type="text/javascript" data-name="foo"></script>';
         $actual = $blockExternalContentHelper->blockScripts(
             $markup,
             true,
@@ -134,7 +143,7 @@ class CookiePunchTest extends UnitTestCase
     /**
      * @test
      */
-    public function strangeScriptTagsWillNeverBeBlocked()
+    public function scriptTagsWithSpecialMimetypesWillNeverBeBlocked()
     {
         $blockExternalContentHelper = new CookiePunch();
         ObjectAccess::setProperty(
@@ -148,6 +157,11 @@ class CookiePunchTest extends UnitTestCase
 
         $markup = '<script type="text/plain"></script>';
         $expected = '<script type="text/plain"></script>';
+        $actual = $blockExternalContentHelper->blockScripts($markup);
+        self::assertEquals($expected, $actual);
+
+        $markup = '<script type="application/ld+json"></script>';
+        $expected = '<script type="application/ld+json"></script>';
         $actual = $blockExternalContentHelper->blockScripts($markup);
         self::assertEquals($expected, $actual);
     }
@@ -322,7 +336,7 @@ class CookiePunchTest extends UnitTestCase
         // <script>
         $markup = '<script src="Packages/Vendor.Example/myscripts.js"/>';
         $expected =
-            '<script data-src="Packages/Vendor.Example/myscripts.js" data-name="default" data-options="{&quot;foo&quot;:&quot;bar&quot;}"/>';
+            '<script data-src="Packages/Vendor.Example/myscripts.js" data-type="text/javascript" data-name="default" data-options="{&quot;foo&quot;:&quot;bar&quot;}"/>';
         $actual = $blockExternalContentHelper->blockScripts($markup);
         self::assertEquals($expected, $actual);
 

--- a/Tests/Unit/TagHelperTest.php
+++ b/Tests/Unit/TagHelperTest.php
@@ -5,7 +5,7 @@ use Neos\Flow\Tests\UnitTestCase;
 use Sandstorm\CookiePunch\TagHelper;
 
 /**
- * Testcase for the ConvertNodeUris Fusion implementation
+ * Testcase
  */
 class TagHelperTest extends UnitTestCase
 {
@@ -14,6 +14,25 @@ class TagHelperTest extends UnitTestCase
      */
     public function tagHelper()
     {
+        // ### Get Value of attribute ###
+        $markup = '<div style="with-style" data-foo="bar"></div>';
+        $expected = 'with-style';
+        $actual = TagHelper::tagGetAttributeValue($markup, 'style');
+
+        self::assertEquals($expected, $actual);
+
+        $markup = '<div style="with-style" data-type="text/application"></div>';
+        $expected = 'text/application';
+        $actual = TagHelper::tagGetAttributeValue($markup, 'data-type');
+
+        self::assertEquals($expected, $actual);
+
+        $markup = '<div style="with-style" data-foo="bar"></div>';
+        $expected = null;
+        $actual = TagHelper::tagGetAttributeValue($markup, 'no-attribute');
+
+        self::assertEquals($expected, $actual);
+
         // ### Rename Attribute ###
         $markup = '<div style="with-style" data-foo="bar"></div>';
         $expected = '<div data-style="with-style" data-foo="bar"></div>';


### PR DESCRIPTION
* a data attribute was missing for Klaro to recover the original type
* type="application/json+ld" will no longer be blocked
* less invasive manipulation of the html of a page, now reusing the original type instead of setting everything to "text/javascript"

Checklist:
- [x] Tests
- [x] Example Project