### PR TITLE
Bugfix: Pass remaining services via context to the Config fusion object.

### DIFF
--- a/Resources/Private/Fusion/Config.fusion
+++ b/Resources/Private/Fusion/Config.fusion
@@ -1,59 +1,57 @@
-prototype(Sandstorm.CookiePunch:Config) < prototype(Neos.Fusion:Component) {
-    services = null
+prototype(Sandstorm.CookiePunch:Config) < prototype(Neos.Fusion:DataStructure) {
+    // servicesRemaining must be passed via the context
 
-    renderer = Neos.Fusion:DataStructure {
-        consent = Neos.Fusion:DataStructure {
-            privacyPolicyUrl = ${CookiePunchConfig.translate("Sandstorm.CookiePunch.consent.privacyPolicyUrl")}
+    consent = Neos.Fusion:DataStructure {
+        privacyPolicyUrl = ${CookiePunchConfig.translate("Sandstorm.CookiePunch.consent.privacyPolicyUrl")}
 
-            elementID = ${Configuration.setting("Sandstorm.CookiePunch.consent.elementID")}
-            noAutoLoad = ${Configuration.setting("Sandstorm.CookiePunch.consent.noAutoLoad")}
-            htmlTexts = ${Configuration.setting("Sandstorm.CookiePunch.consent.htmlTexts")}
-            embedded = ${Configuration.setting("Sandstorm.CookiePunch.consent.embedded")}
-            groupByPurpose = ${Configuration.setting("Sandstorm.CookiePunch.consent.groupByPurpose")}
-            storageMethod = ${Configuration.setting("Sandstorm.CookiePunch.consent.storageMethod")}
-            cookieName = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookieName")}
-            cookieExpiresAfterDays = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookieExpiresAfterDays")}
-            default = ${Configuration.setting("Sandstorm.CookiePunch.consent.default")}
-            mustConsent = ${Configuration.setting("Sandstorm.CookiePunch.consent.mustConsent")}
-            acceptAll = ${Configuration.setting("Sandstorm.CookiePunch.consent.acceptAll")}
-            hideDeclineAll = ${Configuration.setting("Sandstorm.CookiePunch.consent.hideDeclineAll")}
-            hideLearnMore = ${Configuration.setting("Sandstorm.CookiePunch.consent.hideLearnMore")}
-            noticeAsModal = ${Configuration.setting("Sandstorm.CookiePunch.consent.noticeAsModal")}
-            disablePoweredBy = ${Configuration.setting("Sandstorm.CookiePunch.consent.disablePoweredBy")}
-            additionalClass = ${Configuration.setting("Sandstorm.CookiePunch.consent.additionalClass")}
-            cookiePath = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookiePath")}
-            cookieDomain = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookieDomain")}
+        elementID = ${Configuration.setting("Sandstorm.CookiePunch.consent.elementID")}
+        noAutoLoad = ${Configuration.setting("Sandstorm.CookiePunch.consent.noAutoLoad")}
+        htmlTexts = ${Configuration.setting("Sandstorm.CookiePunch.consent.htmlTexts")}
+        embedded = ${Configuration.setting("Sandstorm.CookiePunch.consent.embedded")}
+        groupByPurpose = ${Configuration.setting("Sandstorm.CookiePunch.consent.groupByPurpose")}
+        storageMethod = ${Configuration.setting("Sandstorm.CookiePunch.consent.storageMethod")}
+        cookieName = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookieName")}
+        cookieExpiresAfterDays = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookieExpiresAfterDays")}
+        default = ${Configuration.setting("Sandstorm.CookiePunch.consent.default")}
+        mustConsent = ${Configuration.setting("Sandstorm.CookiePunch.consent.mustConsent")}
+        acceptAll = ${Configuration.setting("Sandstorm.CookiePunch.consent.acceptAll")}
+        hideDeclineAll = ${Configuration.setting("Sandstorm.CookiePunch.consent.hideDeclineAll")}
+        hideLearnMore = ${Configuration.setting("Sandstorm.CookiePunch.consent.hideLearnMore")}
+        noticeAsModal = ${Configuration.setting("Sandstorm.CookiePunch.consent.noticeAsModal")}
+        disablePoweredBy = ${Configuration.setting("Sandstorm.CookiePunch.consent.disablePoweredBy")}
+        additionalClass = ${Configuration.setting("Sandstorm.CookiePunch.consent.additionalClass")}
+        cookiePath = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookiePath")}
+        cookieDomain = ${Configuration.setting("Sandstorm.CookiePunch.consent.cookieDomain")}
 
-            // With the current version of Klaro this is not working for the inline UI (e.g. if iframes are replaced)
+        // With the current version of Klaro this is not working for the inline UI (e.g. if iframes are replaced)
             // Check out the workaround in `Consent.fusion`
             // styling = ${Configuration.setting("Sandstorm.CookiePunch.consent.styling")} -> not stable enougth
 
-            purposes = Neos.Fusion:Map {
-                items = ${Configuration.setting("Sandstorm.CookiePunch.consent.purposes")}
-                itemRenderer = Neos.Fusion:DataStructure {
-                    name = ${itemKey}
-                    title = ${CookiePunchConfig.translate(item.title)}
-                    description = ${CookiePunchConfig.translate(item.description)}
-                }
+        purposes = Neos.Fusion:Map {
+            items = ${Configuration.setting("Sandstorm.CookiePunch.consent.purposes")}
+            itemRenderer = Neos.Fusion:DataStructure {
+                name = ${itemKey}
+                title = ${CookiePunchConfig.translate(item.title)}
+                description = ${CookiePunchConfig.translate(item.description)}
             }
-
-            services = Neos.Fusion:Map {
-                items = ${props.services}
-                itemRenderer = Neos.Fusion:DataStructure {
-                    name = ${itemKey}
-                    title = ${CookiePunchConfig.translate(item.title)}
-                    description = ${CookiePunchConfig.translate(item.description)}
-                    purposes = ${item.purposes}
-                    contextualConsentOnly = ${item.contextualConsentOnly}
-                    default = ${item.default}
-                    cookies = ${item.cookies}
-                    required = ${item.required}
-                    optOut = ${item.optOut}
-                    onlyOnce = ${item.onlyOnce}
-                }
-            }
-
-            translations = Sandstorm.CookiePunch:Config.Translations
         }
+
+        services = Neos.Fusion:Map {
+            items = ${servicesRemaining}
+            itemRenderer = Neos.Fusion:DataStructure {
+                name = ${itemKey}
+                title = ${CookiePunchConfig.translate(item.title)}
+                description = ${CookiePunchConfig.translate(item.description)}
+                purposes = ${item.purposes}
+                contextualConsentOnly = ${item.contextualConsentOnly}
+                default = ${item.default}
+                cookies = ${item.cookies}
+                required = ${item.required}
+                optOut = ${item.optOut}
+                onlyOnce = ${item.onlyOnce}
+            }
+        }
+
+        translations = Sandstorm.CookiePunch:Config.Translations
     }
 }

--- a/Resources/Private/Fusion/Consent.fusion
+++ b/Resources/Private/Fusion/Consent.fusion
@@ -14,7 +14,7 @@ prototype(Sandstorm.CookiePunch:Consent) < prototype(Neos.Fusion:Component) {
 
     renderer = Neos.Fusion:Value {
         @context.cookiePunchConfig = Sandstorm.CookiePunch:Config {
-            services = ${props.servicesRemainingAfterWhenConditions}
+            @context.servicesRemaining = ${props.servicesRemainingAfterWhenConditions}
         }
         @context.cookiePunchConfig.@process.toJson = ${Json.stringify(value)}
         @context.cookiePunch = Neos.Fusion:Case {


### PR DESCRIPTION
This fixes a breaking change that was introduced before by changing its type to Neos.Fusion:Component. The keys for overriding configuration as described in the README did not work anymore because there was a new intermediate key "renderer".